### PR TITLE
Expose duration field to Python bindings.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,11 @@ impl Song {
     }
 
     #[getter]
+    fn duration(&self) -> f64 {
+        self.inner.duration.to_owned().as_secs_f64()
+    }
+
+    #[getter]
     fn track_number(&self) -> Option<String> {
         self.inner.track_number.to_owned()
     }


### PR DESCRIPTION
Expose Rust's Duration object with analysed song's length to Python by converting it into f64 (python float), representing duration in seconds with fractional part.

Fixes #1 